### PR TITLE
Fix bug preventing access to formal parameters in addition to variables

### DIFF
--- a/Chapter05/tinylang/include/tinylang/AST/AST.h
+++ b/Chapter05/tinylang/include/tinylang/AST/AST.h
@@ -217,6 +217,7 @@ public:
     EK_Int,
     EK_Bool,
     EK_Var,
+    EK_Param,
     EK_Const,
     EK_Func,
   };
@@ -303,18 +304,30 @@ public:
 };
 
 class VariableAccess : public Expr {
-  Decl *Var;
+  VariableDeclaration *Var;
 
 public:
   VariableAccess(VariableDeclaration *Var)
       : Expr(EK_Var, Var->getType(), false), Var(Var) {}
-  VariableAccess(FormalParameterDeclaration *Param)
-      : Expr(EK_Var, Param->getType(), false), Var(Param) {}
 
   Decl *getDecl() { return Var; }
 
   static bool classof(const Expr *E) {
     return E->getKind() == EK_Var;
+  }
+};
+
+class FormalParameterAccess : public Expr {
+  FormalParameterDeclaration *Param;
+
+public:
+  FormalParameterAccess(FormalParameterDeclaration *Param)
+      : Expr(EK_Param, Param->getType(), false), Param(Param) {}
+
+  Decl *getDecl() { return Param; }
+
+  static bool classof(const Expr *E) {
+    return E->getKind() == EK_Param;
   }
 };
 
@@ -372,14 +385,14 @@ public:
 };
 
 class AssignmentStatement : public Stmt {
-  VariableDeclaration *Var;
+  Decl *D;
   Expr *E;
 
 public:
-  AssignmentStatement(VariableDeclaration *Var, Expr *E)
-      : Stmt(SK_Assign), Var(Var), E(E) {}
+  AssignmentStatement(Decl *D, Expr *E)
+      : Stmt(SK_Assign), D(D), E(E) {}
 
-  VariableDeclaration *getVar() { return Var; }
+  Decl *getDecl() { return D; }
   Expr *getExpr() { return E; }
 
   static bool classof(const Stmt *S) {

--- a/Chapter05/tinylang/lib/CodeGen/CGProcedure.cpp
+++ b/Chapter05/tinylang/lib/CodeGen/CGProcedure.cpp
@@ -296,6 +296,10 @@ llvm::Value *CGProcedure::emitExpr(Expr *E) {
     // With more languages features in place, here you need
     // to add array and record support.
     return readVariable(Curr, Decl);
+  } else if (auto *Var =
+                 llvm::dyn_cast<FormalParameterAccess>(E)) {
+    auto *Decl = Var->getDecl();
+    return readVariable(Curr, Decl);
   } else if (auto *Const =
                  llvm::dyn_cast<ConstantAccess>(E)) {
     return emitExpr(Const->getDecl()->getExpr());
@@ -313,7 +317,7 @@ llvm::Value *CGProcedure::emitExpr(Expr *E) {
 
 void CGProcedure::emitStmt(AssignmentStatement *Stmt) {
   auto *Val = emitExpr(Stmt->getExpr());
-  writeVariable(Curr, Stmt->getVar(), Val);
+  writeVariable(Curr, Stmt->getDecl(), Val);
 }
 
 void CGProcedure::emitStmt(ProcedureCallStatement *Stmt) {

--- a/Chapter05/tinylang/tools/driver/Driver.cpp
+++ b/Chapter05/tinylang/tools/driver/Driver.cpp
@@ -7,6 +7,7 @@
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Host.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/TargetRegistry.h"


### PR DESCRIPTION
The code as provided is missing some parts that deal with accessing parameters (as opposed to variables).  To demonstrate, run
```
$ ./build/tools/driver/tinylang --emit-llvm examples/Gcd.mod
```
and view the generated `examples/Gcd.ll`.  Note specifically the `while.cond` block does not have instructions for the two assignments to parameters `a` and `b`.  Before my changes:

```
while.cond:                                       ; preds = %while.body, %after.if
  %1 = icmp ne i64 %b, 0
  br i1 %1, label %while.body, label %after.while
```

With my changes:

```
while.cond:                                       ; preds = %while.body, %after.if
  %1 = phi i64 [ %2, %while.body ], [ %a, %after.if ]
  %2 = phi i64 [ %4, %while.body ], [ %b, %after.if ]
  %3 = icmp ne i64 %2, 0
  br i1 %3, label %while.body, label %after.while
```

Also verified with a test program that the generated function produces the correct numerical result.