### PR TITLE
Explicitly mark global variable definition as having 'undefined' value

### DIFF
--- a/Chapter07/tinylang/lib/CodeGen/CGModule.cpp
+++ b/Chapter07/tinylang/lib/CodeGen/CGModule.cpp
@@ -97,10 +97,12 @@ void CGModule::run(ModuleDeclaration *Mod) {
     if (auto *Var =
             llvm::dyn_cast<VariableDeclaration>(Decl)) {
       // Create global variables
+      llvm::Type *T = convertType(Var->getType());
       llvm::GlobalVariable *V = new llvm::GlobalVariable(
-          *M, convertType(Var->getType()),
+          *M, T,
           /*isConstant=*/false,
-          llvm::GlobalValue::PrivateLinkage, nullptr,
+          llvm::GlobalValue::PrivateLinkage,
+          llvm::UndefValue::get(T),
           mangleName(Var));
       Globals[Var] = V;
       if (CGDebugInfo *Dbg = getDbgInfo())


### PR DESCRIPTION
With the code as is, global variable definitions have no initializer, producing invalid IR.  For example, for the following input program to `tinylang`:

```
MODULE Point;

TYPE Point = RECORD X, Y: INTEGER END;

VAR p: Point;

PROCEDURE AssignX(a: INTEGER);
BEGIN
  p.X := a;
END AssignX;

END Point.
```

invoking `build/tools/driver/tinylang --emit-llvm Point.mod` produces this IR for the global variable definition:

```
@_t5Point1p = private global %Point
```

Attempting to process this produces an error:

```
$ llc Point.ll
llc: error: llc: Point.ll:10:1: error: expected value token
define void @_t5Point7AssignX(i64 %a) {
^
```

The simplest way to resolve this is to provide the variable with an 'undefined' initializer; now the IR reads

```
@_t5Point1p = private global %Point undef
```

which can be processed.