### PR TITLE
Fix Chapter 10 JIT Example

### DIFF
--- a/Chapter10/jit/CMakeLists.txt
+++ b/Chapter10/jit/CMakeLists.txt
@@ -9,7 +9,7 @@ include(ChooseMSVCCRT)
 
 add_definitions(${LLVM_DEFINITIONS})
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
-llvm_map_components_to_libnames(llvm_libs Core OrcJIT Support native)
+llvm_map_components_to_libnames(llvm_libs ExecutionEngine Passes Analysis IRReader Core OrcJIT Support native)
 
 if(LLVM_COMPILER_IS_GCC_COMPATIBLE)
   if(NOT LLVM_ENABLE_RTTI)

--- a/Chapter10/jit/main-aarch64.ll
+++ b/Chapter10/jit/main-aarch64.ll
@@ -1,0 +1,11 @@
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "aarch64-unknown-linux-gnu"
+
+declare i32 @printf(i8*, ...)
+
+@hellostr = private unnamed_addr constant [13 x i8] c"Hello world\0A\00"
+
+define i32 @main(i32 %argc, i8** %argv) {
+  %res = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([13 x i8], [13 x i8]* @hellostr, i64 0, i64 0))
+  ret i32 0
+}


### PR DESCRIPTION
The CMakeLists.txt appears to be missing libraries needed to build the example:

```
/usr/bin/ld: CMakeFiles/JIT.dir/JIT.cpp.o: undefined reference to symbol '_ZN4llvm20SectionMemoryManagerC1EPNS0_12MemoryMapperE'
/usr/bin/ld: /usr/local/lib/libLLVMExecutionEngine.so.12: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/JIT.dir/build.make:106: JIT] Error 1
make[1]: *** [CMakeFiles/Makefile2:164: CMakeFiles/JIT.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```

Also, the sample `main.ll`IR will raise an error when run on a non AMD64 architecture:

```
JIT: /home/heksterb/llvm-project/llvm/lib/CodeGen/MachineFunction.cpp:201: void llvm::MachineFunction::init(): Assertion `Target.isCompatibleDataLayout(getDataLayout()) && "Can't create a MachineFunction using a Module with a " "Target-incompatible DataLayout attached\n"' failed.
```
I've included one that works for ARM aarch64 to illustrate that the file is architecture-dependent.